### PR TITLE
Add qonnx support

### DIFF
--- a/utils/export/README.md
+++ b/utils/export/README.md
@@ -1,0 +1,29 @@
+# Export HAWQ to QONNX
+
+### Export Model
+```python 
+from utils.export import ExportManager
+
+...
+
+manager = ExportManager(hawq_model)
+manager.export(
+    torch.randn([1, 16]),  # input for tracing 
+    "hawq2qonnx_model.onnx"
+)
+```
+
+
+### Execute ONNX graph with QONNX operators
+```python
+from qonnx.core.modelwrapper import ModelWrapper
+from qonnx.core.onnx_exec import execute_onnx
+
+...
+
+qonnx_model = ModelWrapper("hawq2qonnx_model.onnx")
+
+input_dict = {"global_in": X_test}  
+
+output_dict = execute_onnx(qonnx_model, input_dict)
+```

--- a/utils/export/__init__.py
+++ b/utils/export/__init__.py
@@ -1,0 +1,2 @@
+from .manager import ExportManager
+from .export_modules import model_info

--- a/utils/export/export_modules.py
+++ b/utils/export/export_modules.py
@@ -1,0 +1,348 @@
+import torch
+import torch.nn as nn
+
+from ..quantization_utils.quant_utils import (
+    SymmetricQuantFunction,
+    symmetric_linear_quantization_params,
+)
+
+from .function import get_quant_func
+from .function import TruncFunc, RoundFunc, ConvFunc
+
+from ..quantization_utils.quant_modules import (
+    QuantAct,
+    QuantDropout,
+    QuantLinear,
+    QuantBnConv2d,
+)
+from ..quantization_utils.quant_modules import (
+    QuantMaxPool2d,
+    QuantAveragePool2d,
+    QuantConv2d,
+)
+
+SUPPORTED_LAYERS = (
+    QuantAct,
+    QuantLinear,
+    QuantConv2d,
+    QuantMaxPool2d,
+    QuantAveragePool2d,
+    QuantDropout,
+    QuantBnConv2d,
+)
+
+model_info = dict()
+model_info["dense_out"] = dict()
+model_info["transformed"] = dict()
+
+# ------------------------------------------------------------
+class ExportQonnxQuantAct(nn.Module):
+    def __init__(self, hawq_layer) -> None:
+        super().__init__()
+        self.hawq_layer = hawq_layer
+        self.export_mode = False
+
+        if self.hawq_layer.full_precision_flag:
+            self.bit_width = 32
+        else:
+            self.bit_width = self.hawq_layer.activation_bit
+
+        self.scale = (
+            self.hawq_layer.act_scaling_factor.clone().detach().requires_grad_(False)
+        )
+
+    def __repr__(self):
+        repr = (
+            f"{self.__class__.__name__}(scale={self.scale.detach().item()}, bitwidth={self.hawq_layer.activation_bit},"
+            + f" full_precision_flag={self.hawq_layer.full_precision_flag}, quant_mode={self.hawq_layer.quant_mode})"
+        )
+        return repr
+
+    def forward(
+        self,
+        x,
+        pre_act_scaling_factor=None,
+        pre_weight_scaling_factor=None,
+        identity=None,
+        identity_scaling_factor=None,
+        identity_weight_scaling_factor=None,
+    ):
+        if type(x) is tuple:
+            pre_act_scaling_factor = x[1]
+            x = x[0]
+        if self.export_mode and pre_act_scaling_factor is None:
+            pre_act_scaling_factor = torch.tensor([1.0], dtype=torch.float32)
+
+        if self.export_mode:
+            return (x, self.scale)
+        else:
+            x, act_scaling_factor = self.hawq_layer(
+                x,
+                pre_act_scaling_factor,
+                pre_weight_scaling_factor,
+                identity,
+                identity_scaling_factor,
+                identity_weight_scaling_factor,
+            )
+            return (x, act_scaling_factor)
+
+
+# ------------------------------------------------------------
+class ExportQonnxQuantLinear(nn.Module):
+    def __init__(self, hawq_layer) -> None:
+        super().__init__()
+        self.hawq_layer = hawq_layer
+        self.export_mode = False
+
+        self.has_bias = hasattr(self.hawq_layer, "bias")
+        in_features, out_features = (
+            self.hawq_layer.weight.shape[1],
+            self.hawq_layer.weight.shape[0],
+        )
+        self.fc = torch.nn.Linear(in_features, out_features, self.has_bias)
+        self.fc.weight.data = torch.transpose(self.hawq_layer.weight_integer, 0, 1)
+        if self.has_bias:
+            self.fc.bias.data = self.hawq_layer.bias_integer
+
+        self.scale = self.hawq_layer.fc_scaling_factor.clone().requires_grad_(False)
+        self.weight_node_inputs = (
+            torch.tensor(1, dtype=torch.float32),  # scale
+            torch.tensor(0, dtype=torch.float32),  # zero point
+            torch.tensor(self.hawq_layer.weight_bit, dtype=torch.float32),  # bit width
+        )
+
+        if self.has_bias:
+            self.bias_node_inputs = (
+                torch.tensor(1, dtype=torch.float32),  # scale
+                torch.tensor(0, dtype=torch.float32),  # zero point
+                torch.tensor(
+                    self.hawq_layer.bias_bit, dtype=torch.float32
+                ),  # bit width
+            )
+
+        self.node_attributes = (
+            int(1 if self.hawq_layer.quant_mode == "symmetric" else 0),  # sign
+            int(0),  # narrow range
+            "ROUND",  # rounding mode
+        )
+
+    def __repr__(self):
+        repr = (
+            f"{self.__class__.__name__}(weight_bit={self.hawq_layer.weight_bit},"
+            + f" bias_bit={self.hawq_layer.bias_bit}, quantize={self.hawq_layer.quant_mode})"
+        )
+        return repr
+
+    def forward(self, x, prev_act_scaling_factor=None):
+        if type(x) is tuple:
+            prev_act_scaling_factor = x[1]
+            x = x[0]
+
+        if self.export_mode:
+            x = x / prev_act_scaling_factor.view(-1)[0]
+
+            quant_node = get_quant_func(self.weight_node_inputs[2].item())
+            weights = quant_node.apply(
+                self.fc.weight.data, *self.weight_node_inputs, *self.node_attributes
+            )
+            x = torch.matmul(x, weights)
+
+            if self.has_bias:
+                quant_node = get_quant_func(self.bias_node_inputs[2].item())
+                bias = quant_node.apply(
+                    self.fc.bias.data, *self.bias_node_inputs, *self.node_attributes
+                )
+                x = torch.add(x, bias)
+
+            # x = torch.round(x)
+            bias_scaling_factor = self.scale * prev_act_scaling_factor.clone()
+            if len(bias_scaling_factor) == 1:
+                x = x * bias_scaling_factor.item()
+            else:
+                x = x * bias_scaling_factor
+            model_info["dense_out"][self.hawq_layer] = x.clone()
+            return x
+        else:
+            x = self.hawq_layer(x, prev_act_scaling_factor)
+            return x
+
+
+# ------------------------------------------------------------
+class ExportQonnxQuantConv2d(nn.Module):
+    def __init__(self, hawq_layer) -> None:
+        super().__init__()
+        self.hawq_layer = hawq_layer
+        self.export_mode = False
+
+        self.conv_scaling_factor = self.hawq_layer.conv_scaling_factor.detach().clone()
+        self.quant_args = (
+            torch.tensor(1, dtype=torch.float32),  # scale
+            torch.tensor(0, dtype=torch.float32),  # zero point
+            torch.tensor(self.hawq_layer.weight_bit, dtype=torch.float32),  # bit width
+            int(1 if self.hawq_layer.quant_mode == "symmetric" else 0),  # sign
+            int(0),  # narrow range
+            "ROUND",  # rounding mode
+        )
+
+        dilation = self.hawq_layer.conv.dilation
+        if type(dilation) != tuple:
+            dilation = (dilation, dilation)
+
+        kernel_size = self.hawq_layer.conv.kernel_size
+        if type(kernel_size) != tuple:
+            kernel_size = (kernel_size, kernel_size)
+
+        pads = self.hawq_layer.conv.padding
+        if type(pads) != tuple:
+            pads = (pads, pads, pads, pads)
+        elif len(pads) == 2:
+            pads = (pads[0], pads[0], pads[1], pads[1])
+
+        strides = self.hawq_layer.conv.stride
+        if type(strides) != tuple:
+            strides = (strides, strides)
+
+        self.conv_args = (
+            dilation,
+            self.hawq_layer.conv.groups,
+            kernel_size,
+            pads,
+            strides,
+        )
+
+    def __repr__(self):
+        repr = f"{self.__class__.__name__}()"
+        return repr
+
+    def forward(self, x, prev_act_scaling_factor=None):
+        if type(x) is tuple:
+            prev_act_scaling_factor = x[1]
+            x = x[0]
+        if x.ndim == 3:
+            # add an extra dimension for batch size
+            x = x[None]
+
+        bias_scaling_factor = self.conv_scaling_factor.view(
+            1, -1
+        ) * prev_act_scaling_factor.view(1, -1)
+        correct_output_scale = bias_scaling_factor.view(1, -1, 1, 1)
+        correct_output_scale = correct_output_scale[0][0][0][0]
+
+        if self.export_mode:
+            QuantFunc = get_quant_func(self.hawq_layer.weight_bit)
+            weights = QuantFunc.apply(self.hawq_layer.weight_integer, *self.quant_args)
+            x = x / prev_act_scaling_factor.item()
+            return (
+                ConvFunc.apply(x, weights, self.hawq_layer, *self.conv_args)
+                * correct_output_scale.item(),
+                self.conv_scaling_factor,
+            )
+        else:
+            x, conv_scaling_factor = self.hawq_layer(x, prev_act_scaling_factor)
+            return (x, conv_scaling_factor)
+
+
+# ------------------------------------------------------------
+class ExportQonnxQuantBnConv2d(nn.Module):
+    def __init__(self, hawq_layer) -> None:
+        super().__init__()
+        self.hawq_layer = hawq_layer
+        self.export_mode = False
+        self.init_conv()
+
+        self.bn = torch.nn.BatchNorm2d(
+            self.hawq_layer.bn.num_features,
+            self.hawq_layer.bn.eps,
+            self.hawq_layer.bn.momentum,
+        )
+
+        self.bn.weight = self.hawq_layer.bn.weight
+        self.bn.bias = self.hawq_layer.bn.bias
+        self.bn.running_mean = self.hawq_layer.bn.running_mean
+        self.bn.running_var = self.hawq_layer.bn.running_var
+
+        self.output_factor = self.bn.weight.view(1, -1, 1, 1) / torch.sqrt(
+            self.bn.running_var + self.bn.eps
+        ).view(1, -1, 1, 1)
+
+    def __repr__(self):
+        s = f"{self.__class__.__name__}()"
+        return s
+
+    def init_conv(self):
+        w_transform = self.hawq_layer.conv.weight.data.contiguous().view(
+            self.hawq_layer.conv.out_channels, -1
+        )
+        w_min = w_transform.min(dim=1).values
+        w_max = w_transform.max(dim=1).values
+        self.conv_scaling_factor = symmetric_linear_quantization_params(
+            self.hawq_layer.weight_bit, w_min, w_max, self.hawq_layer.per_channel
+        )
+        self.weight_integer = SymmetricQuantFunction.apply(
+            self.hawq_layer.conv.weight,
+            self.hawq_layer.weight_bit,
+            self.conv_scaling_factor,
+        )
+
+        quant_layer = QuantConv2d()
+        quant_layer.set_param(self.hawq_layer.conv)
+        quant_layer.weight_integer = self.weight_integer
+        quant_layer.conv_scaling_factor = self.conv_scaling_factor
+        self.export_quant_conv = ExportQonnxQuantConv2d(quant_layer)
+
+    def forward(self, x, pre_act_scaling_factor=None):
+        if type(x) is tuple:
+            pre_act_scaling_factor = x[1]
+            x = x[0]
+
+        if self.export_mode:
+            x, conv_scaling_factor = self.export_quant_conv(x, pre_act_scaling_factor)
+            return (
+                self.bn(x),
+                conv_scaling_factor.view(-1) * self.output_factor.view(-1),
+            )
+        else:
+            x, convbn_scaling_factor = self.hawq_layer(x, pre_act_scaling_factor)
+            return (x, convbn_scaling_factor)
+
+
+# ------------------------------------------------------------
+class ExportQonnxQuantAveragePool2d(nn.Module):
+    def __init__(self, hawq_layer) -> None:
+        super().__init__()
+        self.hawq_layer = hawq_layer
+        self.export_mode = False
+
+        self.trunc_args = (
+            torch.tensor(1),  # scale
+            torch.tensor(0),  # zero point
+            torch.tensor(32),  # input bit width
+            torch.tensor(32),  # output bit width
+            "ROUND",  # rounding mode
+        )
+
+    def __repr__(self):
+        repr = f"{self.__class__.__name__}()"
+        return repr
+
+    def forward(self, x, x_scaling_factor=None):
+        if type(x) is tuple:
+            x_scaling_factor = x[1]
+            x = x[0]
+
+        if x_scaling_factor is None:
+            return (self.hawq_layer(x), x_scaling_factor)
+
+        if self.export_mode:
+            x_scaling_factor = x_scaling_factor.view(-1)
+            correct_scaling_factor = x_scaling_factor
+
+            x_int = x / correct_scaling_factor
+            x_int = RoundFunc.apply(x_int)
+            x_int = self.hawq_layer.final_pool(x_int)
+
+            x_int = TruncFunc.apply(x_int + 0.01, *self.trunc_args)
+
+            return (x_int * correct_scaling_factor, correct_scaling_factor)
+        else:
+            return (self.hawq_layer(x), x_scaling_factor)

--- a/utils/export/export_utils.py
+++ b/utils/export/export_utils.py
@@ -1,0 +1,82 @@
+import struct
+
+import onnx
+from qonnx.util.cleanup import cleanup
+from qonnx.util.to_channels_last import to_channels_last
+import onnxoptimizer
+
+import numpy as np
+
+
+def find_next_op(model, target):
+    for node in model.graph.node:
+        node_inputs = node.input
+        if target in node_inputs:
+            return node
+
+
+def remove_node(model, mul_node, div_node):
+    mul_node_output = mul_node.output[0]
+
+    next_node_after_div = find_next_op(model, div_node.output[0])
+    node_inputs = next_node_after_div.input
+    for idx, node_in in enumerate(node_inputs):
+        if node_in == div_node.output[0]:
+            next_node_after_div.input[idx] = mul_node_output
+
+    model.graph.node.remove(div_node)
+
+
+def merge_nodes(model, mul_node, next_node):
+    if next_node is None or next_node.op_type != "Relu":
+        return
+
+    div_node = find_next_op(model, next_node.output[0])
+    if div_node.op_type != "Div":
+        return
+
+    print(f" - Merging {mul_node.name} with {div_node.name}")
+    mul_param = None
+    mul_param_name = mul_node.name + "_param0"
+    div_param_name = div_node.name + "_param0"
+
+    for param in model.graph.initializer:
+        if param.name == mul_param_name:
+            mul_param = param
+            mul_data = struct.unpack(f"{int(len(param.raw_data)/4)}f", param.raw_data)
+        if param.name == div_param_name:
+            div_data = struct.unpack(f"{int(len(param.raw_data)/4)}f", param.raw_data)
+
+    mul_data = np.array(mul_data)
+    new_mul1_data = mul_data / div_data
+    mul_param.raw_data = struct.pack(f"{len(new_mul1_data)}f", *list(new_mul1_data))
+
+    remove_node(model, next_node, div_node)
+
+
+def merge_quant_linear_scaling(model):
+    for node in model.graph.node:
+        if node.op_type == "Mul":
+            next_node = find_next_op(model, node.output[0])
+            merge_nodes(model, node, next_node)
+
+
+def optimize_onnx_model(model_path):
+    onnx_model = onnxoptimizer.optimize(
+        onnx.load_model(model_path), passes=["extract_constant_to_initializer"]
+    )
+    cleanup(onnx_model, out_file=model_path)
+    to_channels_last(model_path, out_file=model_path)
+
+    onnx_model = onnx.load(model_path)
+    merge_quant_linear_scaling(onnx_model)
+    cleanup(onnx_model, out_file=model_path)
+
+
+def gen_filename():
+    from datetime import datetime
+
+    now = datetime.now()  # current date and time
+    date_time = now.strftime("%m%d%Y_%H%M%S")
+    filename = f"hawq2qonnx_{date_time}.onnx"
+    return filename

--- a/utils/export/function.py
+++ b/utils/export/function.py
@@ -1,0 +1,127 @@
+import torch
+import torch.autograd as autograd
+from torch.onnx import register_custom_op_symbolic
+
+domain_info = {"name": "hawq2qonnx", "version": 1}
+
+
+class QuantFunc(autograd.Function):
+    name = "Quant"
+
+    @staticmethod
+    def forward(
+        ctx, x, scale, zero_point, bit_width, signed, narrow_range, rounding_mode
+    ):
+        n = 2 ** (bit_width.numpy() - 1) - 1
+        x_int = torch.clamp(torch.round((x / scale) + zero_point), -n - 1, n)
+        output = x_int - zero_point
+        output = output * scale
+        return output
+
+    @staticmethod
+    def symbolic(
+        g, x, scale, zero_point, bit_width, signed, narrow_range, rounding_mode
+    ):
+        return g.op(
+            f'{domain_info["name"]}::Quant',
+            x,
+            scale,
+            zero_point,
+            bit_width,
+            signed_i=int(signed),
+            narrow_i=int(narrow_range),
+            rounding_mode_s=rounding_mode,
+        )
+
+
+class BinaryQuantFunc(autograd.Function):
+    name = "BipolarQuant"
+
+    @staticmethod
+    def forward(
+        ctx, x, scale, zero_point, bit_width, signed, narrow_range, rounding_mode
+    ):
+        return x
+
+    @staticmethod
+    def symbolic(
+        g, x, scale, zero_point, bit_width, signed, narrow_range, rounding_mode
+    ):
+        return g.op(f'{domain_info["name"]}::BipolarQuant', x, scale)
+
+
+class TruncFunc(autograd.Function):
+    name = "Trunc"
+
+    @staticmethod
+    def forward(
+        ctx, x, scale, zero_point, input_bit_width, output_bit_width, rounding_mode
+    ):
+        return torch.trunc(x)
+
+    @staticmethod
+    def symbolic(
+        g, x, scale, zero_point, input_bit_width, output_bit_width, rounding_mode
+    ):
+        return g.op(
+            f'{domain_info["name"]}::Trunc',
+            x,
+            scale,
+            zero_point,
+            input_bit_width,
+            output_bit_width,
+            rounding_mode_s=rounding_mode,
+        )
+
+
+class ConvFunc(autograd.Function):
+    name = "Conv"
+
+    @staticmethod
+    def forward(
+        ctx, x, quant_input, layer, dilations, group, kernel_shape, pads, strides
+    ):
+        return layer.conv(x)
+
+    @staticmethod
+    def symbolic(
+        g, x, quant_input, layer, dilations, group, kernel_shape, pads, strides
+    ):
+        return g.op(
+            "Conv",
+            x,
+            quant_input,
+            dilations_i=dilations,
+            group_i=group,
+            kernel_shape_i=kernel_shape,
+            pads_i=pads,
+            strides_i=strides,
+        )
+
+
+class RoundFunc(autograd.Function):
+    name = "Round"
+
+    @staticmethod
+    def forward(ctx, x):
+        return torch.round(x)
+
+    @staticmethod
+    def symbolic(g, x):
+        return g.op(f'{domain_info["name"]}::Round', x)
+
+
+def get_quant_func(bit_width):
+    if bit_width == 1:
+        return BinaryQuantFunc
+    return QuantFunc
+
+
+onnx_funcs = [BinaryQuantFunc, QuantFunc, TruncFunc, RoundFunc, ConvFunc]
+
+
+def register_custom_ops():
+    for func in onnx_funcs:
+        register_custom_op_symbolic(
+            f'{domain_info["name"]}::{func.name}', func.symbolic, domain_info["version"]
+        )

--- a/utils/export/manager.py
+++ b/utils/export/manager.py
@@ -1,0 +1,142 @@
+import copy
+import logging
+import warnings
+
+import torch
+import torch.nn as nn
+
+from .export_utils import optimize_onnx_model, gen_filename
+from .export_modules import model_info
+from .function import register_custom_ops, domain_info
+
+
+from .export_modules import (
+    ExportQonnxQuantAct,
+    ExportQonnxQuantLinear,
+    ExportQonnxQuantConv2d,
+    ExportQonnxQuantAveragePool2d,
+    ExportQonnxQuantBnConv2d,
+)
+from ..quantization_utils.quant_modules import (
+    QuantAct,
+    QuantLinear,
+    QuantBnConv2d,
+    QuantAveragePool2d,
+    QuantConv2d,
+)
+
+SET_EXPORT_MODE = (
+    ExportQonnxQuantAct,
+    ExportQonnxQuantLinear,
+    ExportQonnxQuantConv2d,
+    ExportQonnxQuantAveragePool2d,
+    ExportQonnxQuantBnConv2d,
+)
+
+
+# ------------------------------------------------------------
+class ExportManager(nn.Module):
+    def __init__(self, model) -> None:
+        super().__init__()
+        assert model is not None, "Model is not initialized"
+
+        self.copy_model(model)
+        self.replace_layers()
+
+    def predict(self, x):
+        self.set_export_mode("enable")
+        export_pred = self.export_model(x)
+        return export_pred
+
+    def forward(self, x):
+        self.set_export_mode("disable")
+        hawq_pred = self.export_model(x)
+        self.set_export_mode("enable")
+        export_pred = self.export_model(x)
+        return export_pred, hawq_pred
+
+    def copy_model(self, model):
+        try:
+            self.export_model = copy.deepcopy(model)
+        except Exception as e:
+            logging.error(e)
+            raise Exception(e)
+
+    def replace_layers(self):
+        for param in self.export_model.parameters():
+            param.requires_grad_(False)
+
+        for name in dir(self.export_model):
+            layer = getattr(self.export_model, name)
+            onnx_export_layer = None
+            if isinstance(layer, QuantAct):
+                onnx_export_layer = ExportQonnxQuantAct(layer)
+                setattr(self.export_model, name, onnx_export_layer)
+            elif isinstance(layer, QuantLinear):
+                onnx_export_layer = ExportQonnxQuantLinear(layer)
+                setattr(self.export_model, name, onnx_export_layer)
+            elif isinstance(layer, QuantConv2d):
+                onnx_export_layer = ExportQonnxQuantConv2d(layer)
+                setattr(self.export_model, name, onnx_export_layer)
+            elif isinstance(layer, QuantBnConv2d):
+                onnx_export_layer = ExportQonnxQuantBnConv2d(layer)
+                setattr(self.export_model, name, onnx_export_layer)
+            elif isinstance(layer, QuantAveragePool2d):
+                onnx_export_layer = ExportQonnxQuantAveragePool2d(layer)
+                setattr(self.export_model, name, onnx_export_layer)
+            elif isinstance(layer, nn.Sequential):
+                self.replace_layers(layer)
+            # track changes
+            if onnx_export_layer is not None:
+                model_info["transformed"][layer] = onnx_export_layer
+        for param in self.export_model.parameters():
+            param.requires_grad_(True)
+
+    @staticmethod
+    def enable_export(module):
+        if isinstance(module, SET_EXPORT_MODE):
+            module.export_mode = True
+
+    @staticmethod
+    def disable_export(module):
+        if isinstance(module, SET_EXPORT_MODE):
+            module.export_mode = False
+
+    def set_export_mode(self, export_mode):
+        if export_mode == "enable":
+            self.export_model.apply(self.enable_export)
+        else:
+            self.export_model.apply(self.disable_export)
+
+    def export(self, x, filename=None, save=True):
+        assert x is not None, "Input x is not initialized"
+        assert type(x) is torch.Tensor, "Input x must be a torch.Tensor"
+
+        if filename is None:
+            filename = gen_filename()
+        if len(x) > 1:
+            logging.info("Only [1, ?] dimensions are supported. Selecting first.")
+            x = x[0].view(1, -1)
+        register_custom_ops()
+
+        with torch.no_grad():
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                # collect scaling factors for onnx nodes
+                self.set_export_mode("disable")
+                _ = self.export_model(x)
+                # export with collected values
+                self.set_export_mode("enable")
+                if save:
+                    print("Exporting model...")
+                    torch.onnx.export(
+                        model=self.export_model,
+                        args=x,
+                        f=filename,
+                        opset_version=11,
+                        operator_export_type=torch.onnx.OperatorExportTypes.ONNX,
+                        custom_opsets={domain_info["name"]: 1},
+                    )
+                    print("Optimizing...")
+                    optimize_onnx_model(filename)
+                    print(f"Model saved to: {filename}")


### PR DESCRIPTION
Adding support to export quantized models to the [QONNX](https://github.com/fastmachinelearning/qonnx) format. All layers are supported in this format. While not many model architectures were tested, an MLP and CNN were heavily used with varying settings, such as symmetric and asymmetric quantization, bit-width, etc. A README.md was added to showcase the simplicity of exporting models and executing the onnx graph.  

An additional directory labeled `export` has been added to `utils`. All other files and directories are left unchanged. After exporting models, we perform a post-export optimization step with python packages that need to be installed. These packages are [onnx](https://github.com/onnx/onnx), [qonnx](https://github.com/fastmachinelearning/qonnx), and [onnxoptimizer](https://github.com/onnx/optimizer).

This PR does not include support for [BinaryQuant](https://github.com/fastmachinelearning/qonnx/blob/main/docs/qonnx-custom-ops/bipolar_quant_op.md) nodes. This has been left for a future PR along with further onnx optimizations.  